### PR TITLE
Update Ruby to 2.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.5'
+ruby '2.4.1'
 
 gem 'sinatra'
 gem 'sinatra-flash'


### PR DESCRIPTION
We're getting an error in Travis CI:

>> "'The command "eval bundle install --jobs=3 --retry=3 --deployment ' failed. Retrying, 2 of 3.
>> "Your Ruby version is 2.4.1, but your Gemfile specified 2.2.5"

Maybe updating the Ruby version would fix the problem?