### PR TITLE
Update Dockerfile for Ruby 2.4.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.5
+FROM ruby:2.4.1
 
 ADD Gemfile /app/
 ADD Gemfile.lock /app/


### PR DESCRIPTION
Before updating the Gemfile to Ruby 2.4.1, errors mention the Dockerfile needed to be 2.4.1.

Travis CI is throwing a build error on all tests: 
>> "'The command "eval bundle install --jobs=3 --retry=3 --deployment ' failed. Retrying, 2 of 3.
>> "Your Ruby version is 2.4.1, but your Gemfile specified 2.2.5"

If we update the Gemfile #39 and Dockerfile, the checks will run successfully? Maybe? 

I am trying to add ids to checkboxes in #38. Brand new to all of this.