### PR TITLE
Add shadow DOM example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.5
+FROM ruby:2.4.1
 
 ADD Gemfile /app/
 ADD Gemfile.lock /app/

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.5'
+ruby '2.4.1'
 
 gem 'sinatra'
 gem 'sinatra-flash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ DEPENDENCIES
   zurb-foundation
 
 RUBY VERSION
-   ruby 2.2.5p319
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.13.6
+   1.17.3

--- a/server.rb
+++ b/server.rb
@@ -159,6 +159,10 @@ class Public < Sinatra::Base
     erb :dropdown
   end
 
+  get '/shadowdom' do
+    erb :shadowdom
+  end
+
   def random_notification_message
     messages = [
       'Action successful',

--- a/views/examples.erb
+++ b/views/examples.erb
@@ -35,6 +35,7 @@
   <li><a href='/nested_frames'>Nested Frames</a></li>
   <li><a href='/notification_message'>Notification Messages</a></li>
   <li><a href='/redirector'>Redirect Link</a></li>
+  <li><a href='/shadowdom'>Shadow Dom</a></li>
   <li><a href='/download_secure'>Secure File Download</a></li>
   <li><a href='/shifting_content'>Shifting Content</a></li>
   <li><a href='/slow'>Slow Resources</a></li>

--- a/views/shadowdom.erb
+++ b/views/shadowdom.erb
@@ -1,0 +1,43 @@
+<h1>Simple template</h1>
+
+<script>
+    customElements.define('my-paragraph',
+        class extends HTMLElement {
+            constructor() {
+                super();
+
+                const template = document.getElementById('my-paragraph');
+                const templateContent = template.content;
+
+                this.attachShadow({mode: 'open'}).appendChild(
+                    templateContent.cloneNode(true)
+                );
+            }
+        }
+    );
+
+    const slottedSpan = document.querySelector('my-paragraph span');
+
+</script>
+
+<template id="my-paragraph">
+  <style>
+    p {
+      color: white;
+      background-color: #666;
+      padding: 5px;
+    }
+  </style>
+  <p><slot name="my-text">My default text</slot></p>
+</template>
+
+<my-paragraph>
+  <span slot="my-text">Let's have some different text!</span>
+</my-paragraph>
+
+<my-paragraph>
+  <ul slot="my-text">
+    <li>Let's have some different text!</li>
+    <li>In a list!</li>
+  </ul>
+</my-paragraph>


### PR DESCRIPTION
Added an example that uses shadow DOM.
Used the Mozilla example: https://github.com/mdn/web-components-examples/tree/master/simple-template